### PR TITLE
Fix Selecting Future/Past Dates from Calendar

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -1014,10 +1014,10 @@
 
                 selectDay: function (e) {
                     var day = viewDate.clone();
-                    if ($(e.target).is('.old')) {
+                    if ($(e.currentTarget).is('.old')) {
                         day.subtract(1, 'M');
                     }
-                    if ($(e.target).is('.new')) {
+                    if ($(e.currentTarget).is('.new')) {
                         day.add(1, 'M');
                     }
                     setValue(day.date(parseInt($(e.target).text(), 10)));


### PR DESCRIPTION
If you select a past or future date, the month is not decremented/incremented correctly.

This is because the value of `t.target` is for the nested div which contains the number, not for the div which has the date handler. When the `.is` test checks `t.target` for `.old` and `.new`, they are never present. Instead, use `t.currentTarget` to specify the element which is handling the event.

This issue appears to be in present in the latest version of the code as well.

The only reason I'm submitting this is because I'm using Creative Tim's Dashboard, which uses a modified version of this library.